### PR TITLE
Restore Anchor colors in Markdown

### DIFF
--- a/src/components/admin/events/EventDetails.tsx
+++ b/src/components/admin/events/EventDetails.tsx
@@ -21,7 +21,7 @@ export default function EventDetails({ event, qrCodeValue }: EventDetailsProps) 
 		["Event Name", event.name],
 		["Event Start", format(event.eventStart, "M/dd/yyyy h:mm a")],
 		["Event End", format(event.eventEnd, "M/dd/yyyy h:mm a")],
-		["Description", <ReactMarkdown>{event.description}</ReactMarkdown>],
+		["Description", <ReactMarkdown className="markdown">{event.description}</ReactMarkdown>],
 	];
 
 	const doQrDownload = () => {

--- a/src/pages/events/[id]/index.tsx
+++ b/src/pages/events/[id]/index.tsx
@@ -165,7 +165,7 @@ const EventView: NextPage<{ json: string }> = ({ json }) => {
 										{relativeText}
 									</p>
 									{event.description != null && event.description.length > 0 ? (
-										<ReactMarkdown className="mt-3 [&>*]:my-0" remarkPlugins={[remarkGfm]}>
+										<ReactMarkdown className="mt-3 [&>*]:my-0 markdown" remarkPlugins={[remarkGfm]}>
 											{event.description!}
 										</ReactMarkdown>
 									) : (

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -3,6 +3,7 @@
 @import url("https://fonts.googleapis.com/css2?family=Roboto+Mono&display=swap");
 
 @import "animations";
+@import "markdown";
 
 @tailwind base;
 @tailwind components;

--- a/src/styles/markdown.scss
+++ b/src/styles/markdown.scss
@@ -1,0 +1,16 @@
+/* 
+    Styles for markdown rendered components.
+*/
+.markdown {
+    // Restores link colors in markdown
+    a {
+        // If this fails on certain browsers, try out these colors: base #0070f3, active #6366f1, #6366f1
+        color: LinkText;
+        &:active {
+            color: ActiveText;
+        }
+        &:visited {
+            color: VisitedText;
+        }
+    }
+}


### PR DESCRIPTION
Due to a color definition in the parent components, markdown descriptions don't have dynamic/differentiating colors for anchor tags (links). This PR restores them by adding a new Sass file which uses browser-defined colors & applies them for links, active links & visited links.

Fixes #25 

Tested in Firefox & Chrome locally.

### Before

![image](https://github.com/acmutsa/Portal/assets/44609630/e2616832-08c5-4f6a-be89-1a4df300a88d)

### After

![image](https://github.com/acmutsa/Portal/assets/44609630/b2069f84-2d01-4ea9-bdf1-779e2644833d)


Visited state

![image](https://github.com/acmutsa/Portal/assets/44609630/36406ed8-2ba2-4285-a21d-8e8f28b40b28)
